### PR TITLE
feat(tools): add nested object and array support to LLMToolParameter …

### DIFF
--- a/src/tools/base/baseTool.ts
+++ b/src/tools/base/baseTool.ts
@@ -1,14 +1,15 @@
 export type LLMToolParameter = {
   type: "object";
-  properties: Record<
-    string,
-    {
-      type: "string" | "number" | "boolean" | "object" | "array";
-      description?: string;
-      example?: any;
-    }
-  >;
+  properties: Record<string, LLMToolParameterField>;
   required?: string[];
+};
+
+export type LLMToolParameterField = {
+  type: "string" | "number" | "boolean" | "object" | "array";
+  description?: string;
+  example?: any;
+  properties?: Record<string, LLMToolParameterField>; // for nested object support
+  items?: LLMToolParameterField; // for array of items
 };
 
 export type InputSchema = {


### PR DESCRIPTION
…schema

- Extended `LLMToolParameterField` with `properties` and `items` to support nested object and array definitions.
- Updated `buildDetailedParameterBlock()` to recursively render complex parameter structures.
- Ensured backward compatibility for existing tools.
- Improves tool introspection, documentation, and LLM prompt accuracy.