### PR TITLE
fix: five latent bugs from full-source review

### DIFF
--- a/src/agents/agent.helper.ts
+++ b/src/agents/agent.helper.ts
@@ -330,18 +330,10 @@ export async function recursiveToolWorker(
 export async function delegateTo(
   agent: Agent,
   output: string,
-  inputs: Record<string, string>,
-  currentDepth: number = 0,
-  maxDepth: number = 3
+  inputs: Record<string, string>
 ): Promise<{ delegateTo: string; task: string } | null> {
+  // Per-agent delegation cap is enforced by canDelegate() (Agent.MAX_DELEGATION).
   if (!agent.canDelegate()) return null;
-
-  if (currentDepth >= maxDepth) {
-    console.warn(
-      `🚫 Delegation depth limit (${maxDepth}) reached for ${agent.name}`
-    );
-    return null;
-  }
 
   const match = output.match(/DELEGATE\(([^,]+),\s*"([^"]+)"\)/);
   if (!match) return null;

--- a/src/agents/agent.ts
+++ b/src/agents/agent.ts
@@ -344,7 +344,7 @@ export class Agent {
     }
 
     if (this.canDelegate() && checkDelegate(output)) {
-      const delegation = await delegateTo(this, output, inputs, 0);
+      const delegation = await delegateTo(this, output, inputs);
       if (delegation) {
         return JSON.stringify({ __delegate__: delegation, __depth__: 1 });
       }

--- a/src/engine/taskForce.test.ts
+++ b/src/engine/taskForce.test.ts
@@ -28,19 +28,6 @@ jest.mock("../agents/smartManagerAgent", () => {
     SmartManagerAgent: jest.fn().mockImplementation(() => ({
       setVerbose: jest.fn(),
       planTasks: jest.fn((tasks) => tasks),
-      decomposeTask: jest.fn(),
-      assignAgent: jest.fn(),
-      evaluateTaskOutput: jest.fn(() => ({ action: "accept" })),
-      reviewFinalOutput: jest.fn(() => ({ action: "accept" })),
-    })),
-  };
-});
-
-jest.mock("../agents/smartManagerAgent", () => {
-  return {
-    SmartManagerAgent: jest.fn().mockImplementation(() => ({
-      setVerbose: jest.fn(),
-      planTasks: jest.fn((tasks) => tasks),
       decomposeTask: jest.fn((mainTask, agents, verbose) => [mainTask]),
       assignAgent: jest.fn(),
       evaluateTaskOutput: jest.fn((task, finalOutput) => {
@@ -202,11 +189,7 @@ describe("TaskForce", () => {
     // veya throw etmesini bekliyorsan .rejects.toThrow
   });
 
-  it("should replan and then stop at replan limit", async () => {
-    // context __replanCount__ >= maxGlobalReplanLimit olduğunda tekrar replan yapmamalı
-  });
+  it.todo("should replan and then stop at replan limit");
 
-  it("should use tool handler if TOOL() pattern present in output", async () => {
-    // ToolExecutor ve tool mock’ları ile
-  });
+  it.todo("should use tool handler if TOOL() pattern present in output");
 });

--- a/src/engine/taskForce.ts
+++ b/src/engine/taskForce.ts
@@ -733,7 +733,7 @@ export class TaskForce extends EventEmitter {
         context,
         task.description,
         task.outputFormat,
-        toolResult,
+        summarized,
         undefined,
         "Output was tool result",
         undefined,

--- a/src/llm/aiClient.ts
+++ b/src/llm/aiClient.ts
@@ -253,7 +253,7 @@ async function callAIModelFunc(
           Authorization: `Bearer ${config.apiKey}`,
         },
         body: JSON.stringify({
-          model: config.model,
+          model: config.model.name,
           messages,
           temperature: modelOptions.temperature || 0.7,
           top_p: modelOptions.top_p || 1,

--- a/src/tools/tools/StableDiffusionTool.ts
+++ b/src/tools/tools/StableDiffusionTool.ts
@@ -23,10 +23,16 @@ export class StableDiffusionTool extends Tool {
   async handler(args: { prompt: string }) {
     try {
       const apiKey = process.env.REPLICATE_API_KEY;
+      if (!apiKey) throw new Error("REPLICATE_API_KEY is missing.");
+      const version = process.env.REPLICATE_MODEL_VERSION;
+      if (!version)
+        throw new Error(
+          "REPLICATE_MODEL_VERSION is not set. Provide the Replicate model version hash via the REPLICATE_MODEL_VERSION env variable."
+        );
       const res = await axios.post(
         "https://api.replicate.com/v1/predictions",
         {
-          version: "your-model-version",
+          version,
           input: { prompt: args.prompt },
         },
         {


### PR DESCRIPTION
## Summary

Five latent defects found during a full read of `src/`. Each is small, value-preserving, and independent. No behavior change except where the previous behavior was a bug.

| # | File | Fix |
|---|------|-----|
| 1 | `engine/taskForce.ts` | `handleDelegationAndToolOutput` fed raw `toolResult` to the rerun while computing an unused `summarized`; now feeds `summarized` so long tool outputs are summarized as intended (dead code + lost token savings). |
| 2 | `llm/aiClient.ts` | DeepSeek branch sent `model: config.model` (the whole `LLMModel` object); now `config.model.name`, matching local/anthropic/gemini/openai. The object would serialize wrong and the request would fail. |
| 3 | `engine/taskForce.test.ts` | Removed a duplicated `jest.mock("../agents/smartManagerAgent")` (second silently won) and converted two empty, assertion-less stubs (which passed vacuously and inflated the green count) to `it.todo`. |
| 4 | `agents/agent.helper.ts` + `agent.ts` | Removed the dead `currentDepth/maxDepth` gate in `delegateTo` — both call sites always passed depth `0` and the function never recurses, so the gate never fired. The real per-agent cap stays in `canDelegate()` / `Agent.MAX_DELEGATION`. |
| 5 | `tools/tools/StableDiffusionTool.ts` | Replaced the hardcoded `version: "your-model-version"` placeholder with `process.env.REPLICATE_MODEL_VERSION`, and added missing-key guards for `REPLICATE_API_KEY` and the version (consistent with EXA/Firecrawl tools). |

## Notes
- `#4` is purely a clarity/dead-code cleanup — it does **not** change delegation limits. There remain three *distinct* delegation axes by design: hop-chain (`MAX_DELEGATION_HOPS=5`), per-agent lifetime (`Agent.MAX_DELEGATION=3`), per-task resolution rounds (`maxDelegatePerTask=3`).
- `#5` adds a new env var: `REPLICATE_MODEL_VERSION` (required to run StableDiffusionTool).
- Not verified locally (no `node_modules` in this checkout); all changes are type-safe by inspection. CI should run `tsc` + `jest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)